### PR TITLE
Use path modules in README and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ adios-flake.lib.mkFlake {
 };
 ```
 
+### Multi-Module Flake
+
+Modules can be passed as **paths** — the parent directory name is used in
+error messages (e.g., `conflict on checks.foo — defined by module '.../pkgs/flake-module.nix'`):
+
+```nix
+adios-flake.lib.mkFlake {
+  inherit inputs self;
+  systems = [ "x86_64-linux" "aarch64-darwin" ];
+  modules = [
+    ./pkgs/flake-module.nix
+    ./checks/flake-module.nix
+    ./devshell/flake-module.nix
+  ];
+};
+```
+
 ### System-Agnostic Outputs with `withSystem`
 
 ```nix

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -11,8 +11,8 @@
       inherit inputs self;
       systems = [ "x86_64-linux" "aarch64-darwin" ];
       modules = [
-        # Import additional modules
-        (import ./hello/flake-module.nix)
+        # Pass paths directly
+        ./hello/flake-module.nix
       ];
       perSystem = { pkgs, inputs', ... }: {
         # Per-system attributes can be defined here. The inputs'


### PR DESCRIPTION
Passing paths directly instead of import expressions gives better error messages on conflicts — the file path is included in the error.