### PR TITLE
docs: remove duplicate self parameter from examples

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,7 +51,6 @@ Simple constant contributions:
 adios-flake.lib.mkFlake {
   inherit inputs self;
   systems = [ "x86_64-linux" ];
-  self = self;
   modules = [
     ({ pkgs, ... }: { packages.hello = pkgs.hello; })
     ({ self', ... }: { checks.test = self'.packages.hello; })
@@ -82,7 +81,6 @@ adios-flake.lib.mkFlake {
 adios-flake.lib.mkFlake {
   inherit inputs self;
   systems = [ "x86_64-linux" ];
-  self = self;
   perSystem = { pkgs, ... }: { packages.default = pkgs.hello; };
   flake = { withSystem }: {
     nixosConfigurations.myhost = withSystem "x86_64-linux" ({ pkgs, self', ... }:

--- a/docs/writing-modules.md
+++ b/docs/writing-modules.md
@@ -95,7 +95,6 @@ Users and other modules can then contribute to the new category:
 adios-flake.lib.mkFlake {
   inherit inputs self;
   systems = [ "x86_64-linux" ];
-  self = self;
   modules = [
     container-framework.flakeModule
     # Contribute to the declared category


### PR DESCRIPTION

The examples use `inherit inputs self` which already passes self to
mkFlake, so the additional `self = self;` causes a duplicate attribute
error when copy-pasted into a real flake.


