### PR TITLE
Accept absolute paths in config keys

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -469,7 +469,7 @@ let
       # Convert config parameter to adios option paths
       configOptions = listToAttrs (concatMap (key:
         let
-          path = "/${builtins.replaceStrings [ "/" ] [ "/" ] key}";
+          path = if builtins.substring 0 1 key == "/" then key else "/${key}";
         in
         [ { name = path; value = config.${key}; } ]
       ) (attrNames config));


### PR DESCRIPTION
Config keys like "/red-tape/scan" are already valid adios option paths. Prepending another "/" turns them into "//red-tape/scan" which breaks resolution. Pass them through as-is instead of unconditionally prefixing.

Also removes a no-op replaceStrings that replaced "/" with "/".