### PR TITLE
mkFlake: adopt the flake-parts curried signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ nix flake init -t github:Mic92/adios-flake
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ adios-flake, self, ... }:
-    adios-flake.lib.mkFlake {
-      inherit inputs self;
+  outputs = inputs@{ adios-flake, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, ... }: {
         packages.default = pkgs.hello;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3,71 +3,71 @@
 ## `mkFlake`
 
 ```nix
-mkFlake {
-  inputs;          # Required: flake inputs (must include nixpkgs)
-  systems;         # Required: list of system strings
-  self ? null;     # Optional: pass `self` to enable self' in modules
-  perSystem ? null; # Optional: function { pkgs, system, inputs', self, self' } -> attrset
-  modules ? [];    # Optional: list of modules (functions, native adios modules, or attrsets)
-  config ? {};     # Optional: configure third-party module options by name
-  flake ? {};      # Optional: system-agnostic outputs (attrset or function receiving { withSystem })
+mkFlake { inherit inputs; } module
+```
+
+The first argument carries `inputs` (and optionally `specialArgs`). `self` is
+read from `inputs.self` — the standard flake-parts convention.
+
+`module` is a path, attrset, or function. When it's a function, it receives
+`{ inputs, self, lib, withSystem, ... }`. In all cases it resolves to an
+attrset with these (all optional) keys:
+
+| Key | Meaning |
+|---|---|
+| `systems` | List of system strings. Must be set somewhere in the import tree. |
+| `imports` | Further modules — walked recursively, depth-first. |
+| `perSystem` | `{ pkgs, system, inputs', self', lib, ... }` → per-system outputs. |
+| `flake` | System-agnostic outputs. Deep-merged across all imports. |
+| `config` | adios option configuration by native module name. |
+
+### Native adios modules
+
+A native adios module placed in `imports` (recognised by `impl`, `outputs`,
+or `_type = "adiosModule"`) passes straight through to the evaluation
+engine — it isn't walked like a flake-parts module body. See
+[Writing Reusable Modules](writing-modules.md).
+
+### Compatibility note
+
+This is signature-level compatibility with flake-parts — `imports` are
+flattened and merged structurally. There is no `mkIf`, no priorities, no
+submodule options. Simple flake-parts flakes work via
+`inputs.foo.inputs.flake-parts.follows = "adios-flake"`; flakes that lean
+on NixOS module system features (e.g. `flakeModules.partitions`) won't.
+
+## Quick Example
+
+```nix
+{
+  inputs = {
+    adios-flake.url = "github:Mic92/adios-flake";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ adios-flake, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      perSystem = { pkgs, ... }: {
+        packages.default = pkgs.hello;
+      };
+      flake = {
+        nixosModules.default = ./module.nix;
+      };
+    };
 }
 ```
 
-## Module Styles
+## `imports`
 
-### Ergonomic Function (system-dependent)
-
-Functions whose args include `pkgs`, `system`, `inputs'`, or `self'` are evaluated per-system:
-
-```nix
-({ pkgs, system, ... }: {
-  packages.default = pkgs.hello;
-  checks.test = pkgs.runCommand "test" {} "touch $out";
-})
-```
-
-### Ergonomic Function (system-independent)
-
-Functions without system-specific args are memoized across all systems:
+Each entry is a path, attrset, or function (same shape as the root module).
+Paths are imported, functions are called with the top-level args, and the
+resulting attrset's `imports` are recursed in turn.
 
 ```nix
-({ ... }: {
-  packages.meta = "v1";
-})
-```
-
-### Static Attrset
-
-Simple constant contributions:
-
-```nix
-{ packages.meta = "v1"; }
-```
-
-## Cross-Module References with `self'`
-
-```nix
-adios-flake.lib.mkFlake {
-  inherit inputs self;
-  systems = [ "x86_64-linux" ];
-  modules = [
-    ({ pkgs, ... }: { packages.hello = pkgs.hello; })
-    ({ self', ... }: { checks.test = self'.packages.hello; })
-  ];
-};
-```
-
-## Multi-Module Flake
-
-Modules can be passed as **paths** — the parent directory name is used in
-error messages (e.g., `conflict on checks.foo — defined by module '.../pkgs/flake-module.nix'`):
-
-```nix
-adios-flake.lib.mkFlake {
-  inherit inputs self;
+adios-flake.lib.mkFlake { inherit inputs; } {
   systems = [ "x86_64-linux" "aarch64-darwin" ];
-  modules = [
+  imports = [
     ./pkgs/flake-module.nix
     ./checks/flake-module.nix
     ./devshell/flake-module.nix
@@ -75,21 +75,63 @@ adios-flake.lib.mkFlake {
 };
 ```
 
-## System-Agnostic Outputs with `withSystem`
+```nix
+# ./pkgs/flake-module.nix
+{ ... }: {
+  perSystem = { pkgs, ... }: {
+    packages.hello = pkgs.hello;
+  };
+}
+```
+
+## `perSystem`
+
+Called once per system. Its arguments tell the engine whether the closure is
+system-dependent: a `perSystem` that asks for none of `pkgs`/`system`/
+`inputs'`/`self'` is memoized — evaluated once regardless of how many systems
+are configured.
 
 ```nix
-adios-flake.lib.mkFlake {
-  inherit inputs self;
+perSystem = { pkgs, system, self', inputs', ... }: {
+  packages.default = pkgs.hello;
+  checks.test = self'.packages.default;
+};
+```
+
+## `self'` — Cross-Module References
+
+```nix
+adios-flake.lib.mkFlake { inherit inputs; } {
   systems = [ "x86_64-linux" ];
-  perSystem = { pkgs, ... }: { packages.default = pkgs.hello; };
-  flake = { withSystem }: {
-    nixosConfigurations.myhost = withSystem "x86_64-linux" ({ pkgs, self', ... }:
+  imports = [
+    { perSystem = { pkgs, ... }: { packages.hello = pkgs.hello; }; }
+    { perSystem = { self', ... }: { checks.test = self'.packages.hello; }; }
+  ];
+};
+```
+
+## `withSystem` — Bridging to System-Agnostic Outputs
+
+`withSystem` is passed to top-level module functions. Use it to build
+flake-scoped outputs (like `nixosConfigurations`) that need per-system
+values.
+
+```nix
+adios-flake.lib.mkFlake { inherit inputs; } (
+  { withSystem, ... }: {
+    systems = [ "x86_64-linux" ];
+    perSystem = { pkgs, ... }: { packages.default = pkgs.hello; };
+    flake.nixosConfigurations.myhost = withSystem "x86_64-linux" ({ pkgs, self', ... }:
       pkgs.lib.nixosSystem {
         modules = [{
           environment.systemPackages = [ self'.packages.default ];
         }];
       }
     );
-  };
-};
+  }
+);
 ```
+
+`withSystem` is fed back into module arguments lazily through the engine's
+fixpoint. Don't force it while computing `imports` or `systems` — that's a
+genuine cycle.

--- a/docs/writing-modules.md
+++ b/docs/writing-modules.md
@@ -1,7 +1,7 @@
 # Writing Reusable Modules
 
-For simple cases, ergonomic functions and static attrsets are all you need.
-When you're building a reusable module — something published as a flake
+For simple cases, `perSystem` closures and `flake.*` attrsets are all you
+need. When you're building a reusable module — something published as a flake
 input for others to consume — native adios modules give you typed options,
 explicit dependencies, and the ability to declare new output categories.
 
@@ -23,16 +23,21 @@ a dependency on the internal nixpkgs node — this is how native modules access
 }
 ```
 
-Consumers configure them via the `config` parameter:
+Consumers configure them via the `config` key:
 
 ```nix
-adios-flake.lib.mkFlake {
-  inherit inputs self;
+adios-flake.lib.mkFlake { inherit inputs; } {
   systems = [ "x86_64-linux" ];
-  modules = [ treefmt-nix.flakeModule ];
+  imports = [ treefmt-nix.flakeModule ];
   config.treefmt = { projectRootFile = "project.toml"; };
 };
 ```
+
+Native modules are recognised in `imports` by the presence of `impl`,
+`outputs`, or an explicit `_type = "adiosModule"` marker (the marker is only
+needed for the rare options-only or modules-only module that has neither
+`impl` nor `outputs`). They pass straight through to the evaluation engine
+instead of being walked like a flake-parts module body.
 
 ## Output Declarations
 
@@ -92,19 +97,18 @@ Users and other modules can then contribute to the new category:
 
 ```nix
 # User's flake
-adios-flake.lib.mkFlake {
-  inherit inputs self;
+adios-flake.lib.mkFlake { inherit inputs; } {
   systems = [ "x86_64-linux" ];
-  modules = [
+  imports = [
     container-framework.flakeModule
     # Contribute to the declared category
-    ({ system, ... }: {
-      containers.web = mkWebContainer system;
-    })
+    { perSystem = { system, ... }: {
+        containers.web = mkWebContainer system;
+      }; }
     # Read it via self'
-    ({ self', ... }: {
-      checks.container-test = testContainer self'.containers.web;
-    })
+    { perSystem = { self', ... }: {
+        checks.container-test = testContainer self'.containers.web;
+      }; }
   ];
 };
 ```
@@ -163,25 +167,24 @@ as attrset, with configurable options:
 Usage:
 
 ```nix
-adios-flake.lib.mkFlake {
-  inherit inputs self;
+adios-flake.lib.mkFlake { inherit inputs; } {
   systems = [ "x86_64-linux" ];
-  modules = [ treefmt-nix.flakeModule ];
+  imports = [ treefmt-nix.flakeModule ];
   config.treefmt = { projectRootFile = "project.toml"; };
 };
 ```
 
-## Ergonomic Modules Don't Need Declarations
+## perSystem Closures Don't Need Declarations
 
-Simple function modules and static attrsets never need `outputs`. Their
-return keys are automatically treated as `"attrset"` categories:
+`perSystem` closures never need `outputs`. Their return keys are
+automatically treated as `"attrset"` categories:
 
 ```nix
 # This just works — no outputs declaration needed
-({ pkgs, ... }: {
+perSystem = { pkgs, ... }: {
   packages.hello = pkgs.hello;
   checks.test = pkgs.runCommand "test" {} "touch $out";
-})
+};
 ```
 
 Output declarations are only needed when a module:

--- a/lib.nix
+++ b/lib.nix
@@ -12,9 +12,7 @@ let
 
   inherit (builtins)
     attrNames
-    attrValues
     concatMap
-    concatStringsSep
     elem
     filter
     foldl'
@@ -28,11 +26,6 @@ let
     head
     tail
     ;
-
-  # Check if an attrset is a native adios module (has structural keys)
-  adiosStructuralKeys = [ "options" "inputs" "impl" "modules" "outputs" ];
-  isNativeModule = m:
-    isAttrs m && builtins.any (key: m ? ${key}) adiosStructuralKeys;
 
   # Default output category declarations.
   # These are always present even when no module declares outputs.
@@ -120,48 +113,26 @@ let
     let args = functionArgs fn;
     in builtins.any (arg: args ? ${arg}) systemDepArgs;
 
-  # Auto-naming counters
+  # Normalize the engine's input list. By the time we're here the public
+  # `mkFlake` walker has already imported paths and called top-level
+  # functions; the engine sees exactly two shapes:
+  #   - perSystem closures (functions) → wrapped as adios modules
+  #   - native adios modules (attrsets) → used verbatim, given a name
   normalizeModules =
     { modules
-    , perSystem ? null
-    , self ? null
     , flakeInputs ? {}
     , getSelfPrime
-    , withSystem
     }:
     let
-      # Normalize a single module with index for auto-naming
       normalizeOne = idx: mod:
-        if builtins.isPath mod then
-          # Path: import it and use the file path for error messages.
-          # Replace '/' with '-' for the adios tree key (which uses '/'
-          # as a path separator) but keep the original path as `_file`.
-          let
-            pathStr = toString mod;
-            safeName = builtins.replaceStrings [ "/" ] [ "-" ] pathStr;
-            normalized = normalizeFunction safeName (import mod) { inherit self flakeInputs getSelfPrime withSystem; };
-          in
-          normalized // { _file = pathStr; }
-        else if isFunction mod then
-          normalizeFunction idx mod { inherit self flakeInputs getSelfPrime withSystem; }
-        else if isNativeModule mod then
-          # Native adios module - use as-is, ensure it has a name
-          mod // { name = mod.name or "_native_${toString idx}"; }
-        else if isAttrs mod then
-          normalizeStatic idx mod
+        if isFunction mod then
+          normalizeFunction idx mod { inherit flakeInputs getSelfPrime; }
         else
-          throw "mkFlake: module at index ${toString idx} is not a function, attrset, or native adios module";
+          # Native adios module — the public walker only ever passes
+          # functions or native attrsets, never anything else.
+          mod // { name = mod.name or "_native_${toString idx}"; };
 
-      normalizedModules = builtins.genList (idx: normalizeOne idx (builtins.elemAt modules idx)) (length modules);
-
-      # Add perSystem if provided
-      perSystemModule =
-        if perSystem != null then
-          [ (normalizeFunction "_perSystem" perSystem { inherit self flakeInputs getSelfPrime withSystem; isPerSystem = true; }) ]
-        else
-          [];
-
-      allModules = normalizedModules ++ perSystemModule;
+      allModules = builtins.genList (idx: normalizeOne idx (builtins.elemAt modules idx)) (length modules);
 
       # Check for duplicate names
       names = map (m: m.name) allModules;
@@ -179,19 +150,17 @@ let
     then throw "mkFlake: duplicate module name(s): ${builtins.concatStringsSep ", " dups}"
     else allModules;
 
-  # Normalize an ergonomic function module.
-  # getSelfPrime: system → self' attrset (provided lazily by mkFlake)
-  normalizeFunction = idx: fn: { self, flakeInputs, getSelfPrime, withSystem, isPerSystem ? false }:
+  # Wrap a perSystem closure as an adios module.
+  #
+  # The closure's argument set decides whether it routes through the
+  # /nixpkgs node or not. A perSystem that asks for none of
+  # pkgs/system/inputs'/self' has no adios input edge — the diff
+  # propagation in evalModuleTree.override skips it on subsequent
+  # systems, so it evaluates exactly once.
+  normalizeFunction = idx: fn: { flakeInputs, getSelfPrime }:
     let
       args = functionArgs fn;
       sysDep = isSystemDependent fn;
-      name = if isPerSystem then "_perSystem"
-             else if builtins.isInt idx then "_fn_${toString idx}"
-             else toString idx;
-      # Extract lib from the nixpkgs flake input (cheap — no package eval).
-      # The nixpkgs flake always exposes a top-level `lib`.  When nixpkgs
-      # is a plain path (e.g. <nixpkgs> in tests), fall back to importing
-      # just the lib/ subdirectory — no package evaluation needed.
       lib =
         if flakeInputs ? nixpkgs then
           flakeInputs.nixpkgs.lib or (import (flakeInputs.nixpkgs + "/lib"))
@@ -199,7 +168,8 @@ let
           null;
     in
     {
-      inherit name sysDep;
+      name = "_fn_${toString idx}";
+      inherit sysDep;
       inputs = if sysDep then { nixpkgs = { path = "/nixpkgs"; }; } else {};
       impl =
         if sysDep then
@@ -211,20 +181,10 @@ let
               self' = getSelfPrime system;
             in
             fn (builtins.intersectAttrs args {
-              inherit lib pkgs system inputs' self self' withSystem;
+              inherit lib pkgs system inputs' self';
             })
         else
-          { ... }:
-            fn (builtins.intersectAttrs args ({
-              inherit self withSystem;
-            } // (if lib != null then { inherit lib; } else {})));
-    };
-
-  # Normalize a static attrset module
-  normalizeStatic = idx: attrs:
-    {
-      name = "_static_${toString idx}";
-      impl = { ... }: attrs;
+          { ... }: fn (builtins.intersectAttrs args { inherit lib; });
     };
 
   # Build inputs' from flake inputs for a given system
@@ -278,7 +238,6 @@ let
     , guardMod ? _: null
     , outputDeclarations ? null
     , modules
-    , resolveModuleName
     }:
     let
       callableNames = map (m: m.name) (filter (m: m ? impl) modules);
@@ -322,7 +281,7 @@ let
       impl = { results, ... }:
         let
           modPairs = map (modName: {
-            name = resolveModuleName modName;
+            name = modName;
             value = results.${modName};
           }) (attrNames results);
 
@@ -365,12 +324,14 @@ let
       }) systems);
     }) allCategories);
 
-  # The main mkFlake function
-  mkFlake =
+  # The evaluation engine. Private — called by the public `mkFlake` after
+  # the user's module tree has been walked and flattened. Returns
+  # `{ outputs, withSystem }` so the walker can lazily feed `withSystem`
+  # back into top-level module arguments through the let-rec fixpoint.
+  engine =
     { inputs
     , systems
     , modules ? []
-    , perSystem ? null
     , config ? {}
     , flake ? {}
     , self ? null
@@ -406,30 +367,20 @@ let
           inherit pkgs system inputs' self';
         });
 
-      # Normalize all user modules
       normalizedModules = normalizeModules {
-        inherit modules perSystem self getSelfPrime withSystem;
-        inherit flakeInputs;
+        inherit modules getSelfPrime flakeInputs;
       };
 
       moduleNames = map (m: m.name) normalizedModules;
 
-      # Map safe module names back to file paths for error messages
-      moduleFileMap = listToAttrs (
-        filter (x: x.value != null)
-          (map (m: { name = m.name; value = m._file or null; }) normalizedModules)
-      );
-      resolveModuleName = name: moduleFileMap.${name} or name;
-
-      # Resolved names of system-dependent modules
-      sysDepNames = map (m: resolveModuleName m.name)
+      sysDepNames = map (m: m.name)
         (filter (m: m.sysDep or false) normalizedModules);
 
       # Per-system collector (excludes flake-scoped keys)
       collector = mkResultCollector {
         name = "_collector";
         acceptCat = cat: ! elem cat flakeOutputs;
-        inherit outputDeclarations resolveModuleName;
+        inherit outputDeclarations;
         modules = normalizedModules;
       };
 
@@ -442,7 +393,6 @@ let
           then "mkFlake: module '${modName}' produces flake-scoped output but depends on system-specific arguments (pkgs, system, inputs', self'). Split it into a per-system module and a system-independent module that uses `withSystem`."
           else null;
         modules = normalizedModules;
-        inherit resolveModuleName;
       };
 
       # Build the /nixpkgs internal module
@@ -461,7 +411,7 @@ let
       # Root module tree definition
       rootDef = {
         modules =
-          listToAttrs (map (m: { name = m.name; value = builtins.removeAttrs m [ "name" "outputs" "_file" ]; }) normalizedModules)
+          listToAttrs (map (m: { name = m.name; value = builtins.removeAttrs m [ "name" "outputs" ]; }) normalizedModules)
           // { nixpkgs = builtins.removeAttrs nixpkgsModule [ "name" ]; }
           // { _collector = builtins.removeAttrs collector [ "name" ]; }
           // { _flake = builtins.removeAttrs flakeCollector [ "name" ]; };
@@ -535,18 +485,11 @@ let
       moduleFlakeAttrs = flakeCollected.merged;
       flakeOwners = flakeCollected.owners;
 
-      # Resolve the user-provided `flake` parameter
-      userFlakeAttrs =
-        if isFunction flake then
-          flake { inherit withSystem; }
-        else
-          flake;
-
       # Merge module flake outputs with user flake parameter
       allFlakeAttrs = foldl' (acc: cat:
         let
           mVal = moduleFlakeAttrs.${cat} or null;
-          uVal = userFlakeAttrs.${cat} or null;
+          uVal = flake.${cat} or null;
           catOwners = flakeOwners.${cat} or {};
           val =
             if mVal == null then uVal
@@ -556,7 +499,7 @@ let
               mVal uVal;
         in
         acc // { ${cat} = val; }
-      ) {} (attrNames (moduleFlakeAttrs // userFlakeAttrs));
+      ) {} (attrNames (moduleFlakeAttrs // flake));
 
       # Deep-merge transposed per-system outputs with flake-level attrs.
       # Merge goes 2 levels deep (category → system) so that e.g.
@@ -601,7 +544,108 @@ let
         ) allCats);
 
     in
-    mergeOutputs transposed allFlakeAttrs;
+    {
+      outputs = mergeOutputs transposed allFlakeAttrs;
+      inherit withSystem;
+    };
+
+  # Left-biased recursive attrset merge — used to fold `flake.*`
+  # contributions from all modules in the import tree.
+  recursiveMerge = a: b:
+    if isAttrs a && isAttrs b
+    then a // mapAttrs (k: bv: if a ? ${k} then recursiveMerge a.${k} bv else bv) b
+    else b;
+
+  # A native adios module appearing in `imports` is detected structurally
+  # so it can pass straight through to the engine instead of being walked
+  # like a flake-parts module body. `impl` and `outputs` are unique to
+  # adios; `_type` is the explicit escape hatch for the rare options-only
+  # or modules-only native module that has neither.
+  #
+  # `_type` is stripped before the module reaches adios — it's purely a
+  # routing hint for the walker.
+  isAdiosNative = r:
+    r._type or null == "adiosModule"
+    || r ? impl
+    || (r ? outputs && isAttrs r.outputs);
+
+  # Public entrypoint — flake-parts compatible (issue #15).
+  #
+  #   mkFlake { inherit inputs; } module
+  #
+  # `module` is a path, attrset, or function returning an attrset with:
+  #   systems    list of system strings (must be set somewhere in the tree)
+  #   imports    further modules — walked recursively, depth-first
+  #   perSystem  { pkgs, system, inputs', self', lib, ... } -> per-system attrs
+  #   flake      system-agnostic outputs (deep-merged across all modules)
+  #   config     adios option configuration by module name
+  #
+  # Module functions receive `{ inputs, self, lib, withSystem, …specialArgs }`.
+  # `withSystem` comes from the engine via lazy fixpoint — safe to capture
+  # in `flake.*` thunks but must not be forced while computing `imports`
+  # or `systems`.
+  #
+  # Native adios modules (have `impl` / `outputs` / `_type = "adiosModule"`)
+  # placed in `imports` pass through verbatim to the engine.
+  #
+  # This is signature-level compatibility, not full NixOS module semantics:
+  # `imports` are merged structurally, with no `mkIf`, priorities, or
+  # submodule options.
+  mkFlake = args@{ inputs, specialArgs ? {} }: mod:
+    let
+      self = args.self or inputs.self or null;
+      flakeInputs = builtins.removeAttrs inputs [ "self" ];
+      nixpkgsLib =
+        if flakeInputs ? nixpkgs
+        then flakeInputs.nixpkgs.lib or (import (flakeInputs.nixpkgs + "/lib"))
+        else null;
+
+      topArgs = {
+        inherit inputs self;
+        lib = nixpkgsLib;
+        withSystem = eng.withSystem;
+      } // specialArgs;
+
+      # Resolve one node to a plain attrset.
+      resolve = m:
+        if builtins.isPath m || builtins.isString m then resolve (import m)
+        else if isFunction m then m topArgs
+        else if isAttrs m then m
+        else throw "mkFlake: import is not a path, function, or attrset";
+
+      # Depth-first flatten. Adios-native entries are collected verbatim;
+      # flake-parts bodies have their `imports` recursed and stripped.
+      flatten = m:
+        let r = resolve m; in
+        if isAdiosNative r then [ { adios = builtins.removeAttrs r [ "_type" ]; } ]
+        else
+          let children = r.imports or []; in
+          concatMap flatten children
+          ++ [ { body = builtins.removeAttrs r [ "imports" "_file" ]; } ];
+
+      flat = flatten mod;
+      bodies    = map (x: x.body)  (filter (x: x ? body)  flat);
+      adiosMods = map (x: x.adios) (filter (x: x ? adios) flat);
+
+      systemsSet = filter (b: b ? systems) bodies;
+      systems =
+        if systemsSet == [] then throw "mkFlake: no module set `systems`"
+        else (head systemsSet).systems;
+
+      # `perSystem` closures are exactly the ergonomic-function shape the
+      # engine already understands — no wrapping needed. Adios-native
+      # modules go in alongside them.
+      perSystemFns = filter (f: f != null) (map (b: b.perSystem or null) bodies);
+
+      flake  = foldl' recursiveMerge {} (map (b: b.flake  or {}) bodies);
+      config = foldl' (a: b: a // b) {} (map (b: b.config or {}) bodies);
+
+      eng = engine {
+        inherit inputs systems self config flake;
+        modules = perSystemFns ++ adiosMods;
+      };
+    in
+    eng.outputs;
 
 in
 {

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -6,9 +6,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ adios-flake, self, ... }:
-    adios-flake.lib.mkFlake {
-      inherit inputs self;
+  outputs = inputs@{ adios-flake, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, system, ... }: {
         # Per-system attributes can be defined here. The system argument

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -6,12 +6,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ adios-flake, self, ... }:
-    adios-flake.lib.mkFlake {
-      inherit inputs self;
+  outputs = inputs@{ adios-flake, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-darwin" ];
-      modules = [
-        # Pass paths directly
+      imports = [
         ./hello/flake-module.nix
       ];
       perSystem = { pkgs, inputs', ... }: {

--- a/template/multi-module/hello/flake-module.nix
+++ b/template/multi-module/hello/flake-module.nix
@@ -1,8 +1,9 @@
 # Modules can be imported from separate files like this one.
-# This is an ergonomic function module.
 
-{ pkgs, ... }: {
-  # Definitions like this are entirely equivalent to the ones
-  # you may have directly in perSystem.
-  packages.hello = pkgs.hello;
+{ ... }: {
+  perSystem = { pkgs, ... }: {
+    # Definitions like this are entirely equivalent to the ones
+    # you may have directly in perSystem.
+    packages.hello = pkgs.hello;
+  };
 }

--- a/template/package/flake.nix
+++ b/template/package/flake.nix
@@ -6,9 +6,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ adios-flake, self, ... }:
-    adios-flake.lib.mkFlake {
-      inherit inputs self;
+  outputs = inputs@{ adios-flake, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, ... }:
         let

--- a/template/unfree/flake.nix
+++ b/template/unfree/flake.nix
@@ -6,9 +6,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ adios-flake, nixpkgs, self, ... }:
-    adios-flake.lib.mkFlake {
-      inherit inputs self;
+  outputs = inputs@{ adios-flake, nixpkgs, ... }:
+    adios-flake.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-darwin" ];
       perSystem = { system, ... }:
         let

--- a/tests/attrset-merge-declared.nix
+++ b/tests/attrset-merge-declared.nix
@@ -12,10 +12,9 @@ in
 {
   # Two modules with overlapping keys in a declared attrset category throw
   testDeclaredAttrsetCollision = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
+      imports = [
         {
           name = "mod-a";
           outputs = { packages = { type = "attrset"; }; };
@@ -33,10 +32,9 @@ in
 
   # Custom declared attrset category with collision detection
   testCustomAttrsetCollision = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
+      imports = [
         {
           name = "mod-a";
           outputs = { containers = { type = "attrset"; }; };

--- a/tests/collisions.nix
+++ b/tests/collisions.nix
@@ -10,12 +10,11 @@ in
 {
   # Two modules setting the same key within the same category should throw
   testModuleKeyCollision = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
-        ({ ... }: { checks.foo = "from-module-a"; })
-        ({ ... }: { checks.foo = "from-module-b"; })
+      imports = [
+        { perSystem = { ... }: { checks.foo = "from-module-a"; }; }
+        { perSystem = { ... }: { checks.foo = "from-module-b"; }; }
       ];
     }).checks.${sys}.foo;
     expected = true;
@@ -25,12 +24,11 @@ in
   testModuleNoCollision = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ ... }: { checks.foo = "from-module-a"; })
-            ({ ... }: { checks.bar = "from-module-b"; })
+          imports = [
+            { perSystem = { ... }: { checks.foo = "from-module-a"; }; }
+            { perSystem = { ... }: { checks.bar = "from-module-b"; }; }
           ];
         };
       in
@@ -43,12 +41,9 @@ in
 
   # flake attrs colliding with per-system transposed outputs should throw
   testFlakeVsPerSystemCollision = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
-        ({ ... }: { checks.my-check = "from-module"; })
-      ];
+      perSystem = { ... }: { checks.my-check = "from-module"; };
       flake = {
         checks.${sys}.my-check = "from-flake";
       };
@@ -60,12 +55,9 @@ in
   testFlakeVsPerSystemNoCollision = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ ... }: { checks.from-module = "module-val"; })
-          ];
+          perSystem = { ... }: { checks.from-module = "module-val"; };
           flake = {
             checks.${sys}.from-flake = "flake-val";
           };
@@ -82,12 +74,9 @@ in
   testFlakeOnlyCategory = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ ... }: { packages.hello = "hello-pkg"; })
-          ];
+          perSystem = { ... }: { packages.hello = "hello-pkg"; };
           flake = {
             nixosConfigurations.myhost = "myhost-config";
           };

--- a/tests/e2e-custom-category.nix
+++ b/tests/e2e-custom-category.nix
@@ -20,20 +20,18 @@ in
           };
         };
 
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } {
           inherit systems;
-          self = result;
-          modules = [
+          imports = [
             containerFrameworkModule
             # User module contributes to the declared category
-            ({ system, ... }: {
-              containers.web = "nginx-${system}";
-            })
+            { perSystem = { system, ... }: {
+                containers.web = "nginx-${system}";
+              }; }
             # Another user module reads containers via self'
-            ({ self', ... }: {
-              checks.container-exists = "verified-${self'.containers.web}";
-            })
+            { perSystem = { self', ... }: {
+                checks.container-exists = "verified-${self'.containers.web}";
+              }; }
           ];
         };
       in

--- a/tests/e2e-treefmt-style.nix
+++ b/tests/e2e-treefmt-style.nix
@@ -24,15 +24,14 @@ in
           };
         };
 
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           inherit systems;
-          modules = [
+          imports = [
             treefmtModule
             # User module adds its own checks (non-overlapping)
-            ({ system, ... }: {
-              checks.my-test = "test-${system}";
-            })
+            { perSystem = { system, ... }: {
+                checks.my-test = "test-${system}";
+              }; }
           ];
           config.treefmt = { projectRootFile = "project.toml"; };
         };

--- a/tests/fixtures/flake-parts-mod.nix
+++ b/tests/fixtures/flake-parts-mod.nix
@@ -1,0 +1,5 @@
+{ ... }: {
+  perSystem = { system, ... }: {
+    packages.fromFile = "file-" + system;
+  };
+}

--- a/tests/flake-outputs.nix
+++ b/tests/flake-outputs.nix
@@ -12,14 +12,13 @@ in
   testFlakeAndPerSystemRouting = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ "x86_64-linux" "aarch64-linux" ];
-          modules = [
-            ({ system, ... }: { packages.foo = "foo-${system}"; })
-            ({ ... }: { nixosModules.mod-a = "a"; })
-            ({ ... }: { nixosModules.mod-b = "b"; })
-            ({ ... }: { modules.nixos.server = "srv"; })
+          imports = [
+            { perSystem = { system, ... }: { packages.foo = "foo-${system}"; }; }
+            { flake.nixosModules.mod-a = "a"; }
+            { flake.nixosModules.mod-b = "b"; }
+            { flake.modules.nixos.server = "srv"; }
           ];
         };
       in
@@ -37,44 +36,22 @@ in
     };
   };
 
-  # System-dependent module must not produce flake-scoped output.
-  testMixedPerSystemAndFlakeThrows = {
-    expr = throws (
-      let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
-          systems = [ sys ];
-          modules = [
-            ({ system, ... }: {
-              packages.hello = "hello-${system}";
-              nixosModules.mymod = "my-mod";
-            })
-          ];
-        };
-      in
-      result.nixosModules.mymod
-    );
-    expected = true;
-  };
-
-  # withSystem in modules and in the flake parameter both work with self'.
+  # withSystem available to top-level module functions for flake-scoped outputs.
   testWithSystem = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } {
           systems = [ sys ];
-          self = result;
           perSystem = { ... }: { packages.default = "my-pkg"; };
-          modules = [
+          imports = [
             ({ withSystem, ... }: {
-              nixosConfigurations.from-module = withSystem sys ({ self', ... }:
+              flake.nixosConfigurations.from-module = withSystem sys ({ self', ... }:
                 self'.packages.default);
             })
+            ({ withSystem, ... }: {
+              flake.nixosConfigurations.from-flake = withSystem sys ({ system, ... }: system);
+            })
           ];
-          flake = { withSystem }: {
-            nixosConfigurations.from-flake = withSystem sys ({ system, ... }: system);
-          };
         };
       in
       {
@@ -87,16 +64,15 @@ in
     };
   };
 
-  # Module flake outputs merge with `flake` parameter; collisions throw.
+  # `flake.*` from multiple imports deep-merges; perSystem collisions still throw.
   testFlakeMergeAndCollisions = {
     expr =
       let
-        merged = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        merged = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ ... }: { nixosModules.from-module = "module-val"; })
-            ({ ... }: { modules.nixos.from-module = "mod-val"; })
+          imports = [
+            { flake.nixosModules.from-module = "module-val"; }
+            { flake.modules.nixos.from-module = "mod-val"; }
           ];
           flake = {
             nixosModules.from-flake = "flake-val";
@@ -107,26 +83,18 @@ in
       {
         merge = merged.nixosModules;
         modMerge = merged.modules;
-        collisionFlake = throws (lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        collisionPerSystem = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [ ({ ... }: { nixosModules.x = "a"; }) ];
-          flake = { nixosModules.x = "b"; };
-        }).nixosModules.x;
-        collisionModules = throws (lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
-          systems = [ sys ];
-          modules = [
-            ({ ... }: { nixosModules.x = "a"; })
-            ({ ... }: { nixosModules.x = "b"; })
+          imports = [
+            { perSystem = { ... }: { packages.x = "a"; }; }
+            { perSystem = { ... }: { packages.x = "b"; }; }
           ];
-        }).nixosModules.x;
+        }).packages.${sys}.x;
       };
     expected = {
       merge = { from-module = "module-val"; from-flake = "flake-val"; };
       modMerge = { nixos.from-module = "mod-val"; home.from-flake = "home-val"; };
-      collisionFlake = true;
-      collisionModules = true;
+      collisionPerSystem = true;
     };
   };
 
@@ -134,10 +102,9 @@ in
   testCustomFlakeScopedCategory = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "container-mod";
               outputs = { containers = { type = "attrset"; scope = "flake"; }; };

--- a/tests/flake-parts-compat.nix
+++ b/tests/flake-parts-compat.nix
@@ -1,0 +1,185 @@
+# Tests for flake-parts signature compatibility (issue #15)
+#
+# flake-parts uses a curried signature:
+#   mkFlake { inherit inputs; } module
+#
+# where `module` is NixOS-module-style: a path, attrset, or function
+# returning { systems, imports, perSystem, flake }.
+#
+# This lets users do:
+#   inputs.jjui.inputs.flake-parts.follows = "adios-flake";
+#
+# We support the *shape* of the module (imports recursion, perSystem,
+# flake merge) — not the full NixOS module system semantics
+# (no priorities, no mkIf, no submodule options).
+let
+  prelude = import ./prelude.nix;
+  inherit (prelude) lib nixpkgs sys;
+in
+{
+  # Basic curried form: mkFlake { inputs } { systems; perSystem; }
+  testCurriedBasic = {
+    expr =
+      let
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
+          systems = [ sys ];
+          perSystem = { pkgs, system, ... }: {
+            packages.default = "hello-${system}";
+          };
+        };
+      in
+      result.packages.${sys}.default;
+    expected = "hello-${sys}";
+  };
+
+  # Module as a function receiving { inputs, ... }
+  testCurriedFunction = {
+    expr =
+      let
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } (
+          { inputs, ... }: {
+            systems = [ sys ];
+            perSystem = { pkgs, ... }: {
+              packages.hasNixpkgs = if inputs?nixpkgs then "yes" else "no";
+            };
+          }
+        );
+      in
+      result.packages.${sys}.hasNixpkgs;
+    expected = "yes";
+  };
+
+  # imports: multiple modules each contributing perSystem
+  testCurriedImports = {
+    expr =
+      let
+        modA = { ... }: {
+          perSystem = { ... }: {
+            packages.a = "from-a";
+          };
+        };
+        modB = {
+          perSystem = { system, ... }: {
+            packages.b = "from-b-${system}";
+          };
+        };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
+          systems = [ sys ];
+          imports = [ modA modB ];
+          perSystem = { ... }: {
+            packages.top = "from-top";
+          };
+        };
+      in
+      result.packages.${sys};
+    expected = {
+      a = "from-a";
+      b = "from-b-${sys}";
+      top = "from-top";
+    };
+  };
+
+  # Nested imports (imports inside imports)
+  testCurriedNestedImports = {
+    expr =
+      let
+        leaf = { perSystem = { ... }: { packages.leaf = "leaf"; }; };
+        mid = { imports = [ leaf ]; perSystem = { ... }: { packages.mid = "mid"; }; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
+          systems = [ sys ];
+          imports = [ mid ];
+        };
+      in
+      result.packages.${sys};
+    expected = { leaf = "leaf"; mid = "mid"; };
+  };
+
+  # flake.* outputs merged across imports
+  testCurriedFlakeMerge = {
+    expr =
+      let
+        modOverlay = { ... }: {
+          flake.overlays.default = "overlay-fn";
+        };
+        modModule = {
+          flake.nixosModules.foo = "nixos-mod";
+        };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
+          systems = [ sys ];
+          imports = [ modOverlay modModule ];
+          flake.lib.greet = "hello";
+        };
+      in
+      {
+        overlay = result.overlays.default;
+        nixosMod = result.nixosModules.foo;
+        greet = result.lib.greet;
+      };
+    expected = {
+      overlay = "overlay-fn";
+      nixosMod = "nixos-mod";
+      greet = "hello";
+    };
+  };
+
+  # self resolution from inputs.self (flake-parts style)
+  testCurriedSelfFromInputs = {
+    expr =
+      let
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } {
+          systems = [ sys ];
+          perSystem = { self', ... }: {
+            packages.a = "pkg-a";
+            checks.ref = "got-${self'.packages.a}";
+          };
+        };
+      in
+      result.checks.${sys}.ref;
+    expected = "got-pkg-a";
+  };
+
+  # Top-level module function receives self
+  testCurriedSelfArg = {
+    expr =
+      let
+        fakeSelf = { rev = "deadbeef"; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = fakeSelf; }; } (
+          { self, ... }: {
+            systems = [ sys ];
+            flake.rev = self.rev;
+          }
+        );
+      in
+      result.rev;
+    expected = "deadbeef";
+  };
+
+  # Module as a path
+  testCurriedPath = {
+    expr =
+      let
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
+          systems = [ sys ];
+          imports = [ ./fixtures/flake-parts-mod.nix ];
+        };
+      in
+      result.packages.${sys}.fromFile;
+    expected = "file-${sys}";
+  };
+
+  # withSystem available in top-level module functions
+  testCurriedWithSystem = {
+    expr =
+      let
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } (
+          { withSystem, ... }: {
+            systems = [ sys ];
+            perSystem = { ... }: { packages.default = "pkg"; };
+            flake.thing = withSystem sys ({ self', ... }: self'.packages.default);
+          }
+        );
+      in
+      result.thing;
+    expected = "pkg";
+  };
+}

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -12,8 +12,7 @@ in
   testSimpleTemplate = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ "x86_64-linux" "aarch64-linux" ];
           perSystem = { pkgs, system, ... }: {
             packages.default = "hello-${system}";
@@ -30,24 +29,21 @@ in
     };
   };
 
-  # 6.2 Multiple module styles: ergonomic function + native adios module + static attrset
+  # 6.2 Multiple module styles: perSystem closure + native adios module
   testMultipleModuleStyles = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            # Ergonomic function
-            ({ pkgs, ... }: { packages.from-fn = "fn-val"; })
-            # Native adios module
+          imports = [
+            # perSystem closure (ergonomic function)
+            { perSystem = { pkgs, ... }: { packages.from-fn = "fn-val"; }; }
+            # Native adios module — passes straight through to the engine
             {
               name = "native";
               inputs.nixpkgs = { path = "/nixpkgs"; };
               impl = { inputs, ... }: { packages.from-native = inputs.nixpkgs.system; };
             }
-            # Static attrset
-            { packages.from-static = "static-val"; }
           ];
         };
       in
@@ -55,7 +51,6 @@ in
     expected = {
       from-fn = "fn-val";
       from-native = sys;
-      from-static = "static-val";
     };
   };
 
@@ -63,10 +58,9 @@ in
   testThirdPartyConfig = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "treefmt";
               options.projectRootFile = { type = types.string; default = "default.nix"; };
@@ -86,24 +80,24 @@ in
     expected = "flake.nix:alejandra";
   };
 
-  # 6.4 self is available in ergonomic functions
+  # 6.4 self is available in top-level module functions
   testSelfAvailable = {
     expr =
       let
         fakeSelf = { outPath = "/my/flake"; rev = "abc123"; };
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = fakeSelf; }; } {
           systems = [ sys ];
-          self = fakeSelf;
-          modules = [
-            # System-independent function using self
-            ({ self, ... }: { packages.src = self.outPath; })
-            # System-dependent function using self
-            ({ self, system, ... }: { packages.info = "${self.rev}-${system}"; })
+          imports = [
+            # Top-level function using self → flake-scoped output
+            ({ self, ... }: { flake.src = self.outPath; })
+            # self captured in perSystem closure
+            ({ self, ... }: {
+              perSystem = { system, ... }: { packages.info = "${self.rev}-${system}"; };
+            })
           ];
         };
       in
-      result.packages.${sys};
+      { src = result.src; info = result.packages.${sys}.info; };
     expected = {
       src = "/my/flake";
       info = "abc123-${sys}";
@@ -114,15 +108,13 @@ in
   testSelfPrimeCrossModule = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } {
           systems = [ sys ];
-          self = result;
-          modules = [
+          imports = [
             # Module A defines a package
-            ({ pkgs, ... }: { packages.hello = "hello-pkg"; })
+            { perSystem = { pkgs, ... }: { packages.hello = "hello-pkg"; }; }
             # Module B reads module A's package via self'
-            ({ self', ... }: { checks.test = "tested-${self'.packages.hello}"; })
+            { perSystem = { self', ... }: { checks.test = "tested-${self'.packages.hello}"; }; }
           ];
         };
       in
@@ -140,8 +132,7 @@ in
   testLibAvailable = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
           perSystem = { lib, ... }: {
             packages.greeting = lib.concatStringsSep ", " [ "hello" "world" ];
@@ -152,40 +143,37 @@ in
     expected = "hello, world";
   };
 
-  # lib in system-independent module
-  testLibInPureModule = {
+  # lib in top-level module function
+  testLibInTopLevel = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
-          systems = [ sys ];
-          modules = [
-            ({ lib, ... }: { packages.x = lib.optionalString true "yes"; })
-          ];
-        };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } (
+          { lib, ... }: {
+            systems = [ sys ];
+            flake.x = lib.optionalString true "yes";
+          }
+        );
       in
-      result.packages.${sys}.x;
+      result.x;
     expected = "yes";
   };
 
-  # 6.6 withSystem in flake function (nixosConfigurations pattern)
+  # 6.6 withSystem in top-level module (nixosConfigurations pattern)
   testWithSystemFlake = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
-          systems = [ sys ];
-          self = result;
-          perSystem = { pkgs, ... }: {
-            packages.default = "my-default-pkg";
-          };
-          flake = { withSystem }: {
-            nixosConfigurations.myhost = withSystem sys ({ pkgs, self', system, ... }: {
+        result = lib.mkFlake { inputs = { inherit nixpkgs; self = result; }; } (
+          { withSystem, ... }: {
+            systems = [ sys ];
+            perSystem = { pkgs, ... }: {
+              packages.default = "my-default-pkg";
+            };
+            flake.nixosConfigurations.myhost = withSystem sys ({ pkgs, self', system, ... }: {
               system = system;
               defaultPkg = self'.packages.default;
             });
-          };
-        };
+          }
+        );
       in
       {
         system = result.nixosConfigurations.myhost.system;
@@ -203,11 +191,11 @@ in
   testNestedSubmoduleConfig = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
+              _type = "adiosModule";
               name = "treefmt";
               options.projectRootFile = { type = types.string; default = "default.nix"; };
               modules.nixfmt = {

--- a/tests/memoization.nix
+++ b/tests/memoization.nix
@@ -10,14 +10,15 @@ let
   systems = [ "x86_64-linux" "aarch64-linux" ];
 
   # A result using two systems where one module is pure (no pkgs/system dep)
-  result = lib.mkFlake {
-    inputs = { nixpkgs = nixpkgs; };
+  result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
     inherit systems;
-    modules = [
-      # System-independent: should be memoized (evaluated once)
-      ({ ... }: { packages.meta = builtins.trace "PURE_MODULE_EVAL" "v1"; })
+    imports = [
+      # System-independent: a perSystem closure that asks for none of
+      # the per-system args. The engine sees this as a pure ergonomic
+      # function and memoizes it across systems.
+      { perSystem = { ... }: { packages.meta = builtins.trace "PURE_MODULE_EVAL" "v1"; }; }
       # System-dependent: evaluated per system
-      ({ system, ... }: { packages.sys = builtins.trace "SYS_MODULE_EVAL" system; })
+      { perSystem = { system, ... }: { packages.sys = builtins.trace "SYS_MODULE_EVAL" system; }; }
     ];
   };
 in

--- a/tests/module-classification.nix
+++ b/tests/module-classification.nix
@@ -1,13 +1,11 @@
-# Tests for module classification: options-only module, full module, static attrset, function, edge cases
+# Tests for module classification: options-only module, full module, perSystem closures, edge cases
 let
   prelude = import ./prelude.nix;
   inherit (prelude) lib nixpkgs sys;
 
   # Helper to build and get packages for currentSystem
-  mkAndGetPkgs = args: (lib.mkFlake ({
-    inputs = { nixpkgs = nixpkgs; };
-    systems = [ sys ];
-  } // args)).packages.${sys};
+  mkAndGetPkgs = mod: (lib.mkFlake { inputs = { inherit nixpkgs; }; }
+    ({ systems = [ sys ]; } // mod)).packages.${sys};
 
   # Helper: does evaluation throw?
   throws = expr:
@@ -17,16 +15,15 @@ let
     !result.success;
 in
 {
-  # 1. Options-only native module is classified as native (has structural key "options")
+  # 1. Options-only native module needs the explicit `_type = "adiosModule"`
+  # marker since `options` is also a flake-parts module key.
   testOptionsOnlyModule = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            # This has "options" structural key → native adios module
-            { name = "settings"; options.debug = { type = prelude.types.bool; default = false; }; }
+          imports = [
+            { _type = "adiosModule"; name = "settings"; options.debug = { type = prelude.types.bool; default = false; }; }
             # A module that reads options from settings
             { name = "reader"; inputs.settings = { path = "/settings"; }; impl = { inputs, ... }: { packages.debug-val = builtins.toJSON inputs.settings.debug; }; }
           ];
@@ -39,7 +36,7 @@ in
   # 2. Full native module (options + inputs + impl)
   testFullNativeModule = {
     expr = mkAndGetPkgs {
-      modules = [
+      imports = [
         {
           name = "full";
           inputs.nixpkgs = { path = "/nixpkgs"; };
@@ -50,66 +47,27 @@ in
     expected = { sys = sys; };
   };
 
-  # 3. Static attrset is normalized
-  testStaticAttrset = {
+  # 3. perSystem closure (system-dependent)
+  testPerSystemSysDep = {
     expr = mkAndGetPkgs {
-      modules = [
-        { packages.foo = "static-val"; }
-      ];
-    };
-    expected = { foo = "static-val"; };
-  };
-
-  # 4. Ergonomic function (system-dependent)
-  testErgonomicFnSysDep = {
-    expr = mkAndGetPkgs {
-      modules = [
-        ({ pkgs, system, ... }: { packages.sys-info = system; })
-      ];
+      perSystem = { pkgs, system, ... }: { packages.sys-info = system; };
     };
     expected = { sys-info = sys; };
   };
 
-  # 5. Ergonomic function (system-independent)
-  testErgonomicFnPure = {
+  # 4. perSystem closure asking for no per-system args — engine memoizes
+  testPerSystemPure = {
     expr = mkAndGetPkgs {
-      modules = [
-        ({ ... }: { packages.meta = "v1"; })
-      ];
+      perSystem = { ... }: { packages.meta = "v1"; };
     };
     expected = { meta = "v1"; };
   };
 
-  # 6. Edge case: attrset with only "modules" key is treated as native
-  testModulesOnlyNative = {
-    expr =
-      let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
-          systems = [ sys ];
-          modules = [
-            {
-              name = "parent";
-              modules.child = {
-                impl = { ... }: { packages.from-child = "child-val"; };
-              };
-            }
-          ];
-        };
-      in
-      # Parent module has no impl, so no result.
-      # But the module is classified as native (has "modules" key).
-      # This test ensures no error occurs.
-      builtins.attrNames result;
-    expected = [];
-  };
-
-  # 7. Duplicate name detection
+  # 5. Duplicate native module name detection
   testDuplicateNameThrows = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
+      imports = [
         { name = "dup"; impl = { ... }: { packages.a = "a"; }; }
         { name = "dup"; impl = { ... }: { packages.b = "b"; }; }
       ];
@@ -117,15 +75,14 @@ in
     expected = true;
   };
 
-  # 8. Mixed named + anonymous modules
+  # 6. Mixed: named native + anonymous perSystem closures
   testMixedNaming = {
     expr = mkAndGetPkgs {
-      modules = [
+      imports = [
         { name = "named"; impl = { ... }: { packages.named = "named-val"; }; }
-        ({ pkgs, ... }: { packages.anon = "anon-val"; })
-        { packages.static = "static-val"; }
+        { perSystem = { pkgs, ... }: { packages.anon = "anon-val"; }; }
       ];
     };
-    expected = { named = "named-val"; anon = "anon-val"; static = "static-val"; };
+    expected = { named = "named-val"; anon = "anon-val"; };
   };
 }

--- a/tests/output-declarations.nix
+++ b/tests/output-declarations.nix
@@ -11,10 +11,9 @@ in
 {
   # Conflicting declarations should throw
   testConflictingDeclarationsThrow = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
+      imports = [
         {
           name = "mod-a";
           outputs = { foo = { type = "attrset"; }; };
@@ -34,10 +33,9 @@ in
   testConsistentRedeclarations = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "mod-a";
               outputs = { packages = { type = "attrset"; }; };
@@ -59,10 +57,9 @@ in
   testRedeclareDefaultCategory = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "checker";
               outputs = { checks = { type = "attrset"; }; };

--- a/tests/scalar-merge.nix
+++ b/tests/scalar-merge.nix
@@ -13,10 +13,9 @@ in
   testScalarOneProvider = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "fmt";
               outputs = { formatter = { type = "scalar"; }; };
@@ -32,10 +31,9 @@ in
 
   # Two modules provide a scalar output — throws
   testScalarTwoProvidersThrows = {
-    expr = throws (lib.mkFlake {
-      inputs = { nixpkgs = nixpkgs; };
+    expr = throws (lib.mkFlake { inputs = { inherit nixpkgs; }; } {
       systems = [ sys ];
-      modules = [
+      imports = [
         {
           name = "fmt-a";
           outputs = { formatter = { type = "scalar"; }; };
@@ -55,12 +53,9 @@ in
   testScalarZeroProviders = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ pkgs, ... }: { packages.hello = "hello"; })
-          ];
+          perSystem = { pkgs, ... }: { packages.hello = "hello"; };
         };
       in
       result ? formatter;

--- a/tests/scalar-transpose.nix
+++ b/tests/scalar-transpose.nix
@@ -10,10 +10,9 @@ in
   testScalarFormatterShape = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           inherit systems;
-          modules = [
+          imports = [
             {
               name = "treefmt";
               outputs = { formatter = { type = "scalar"; }; };

--- a/tests/transposition.nix
+++ b/tests/transposition.nix
@@ -9,12 +9,9 @@ in
   testSingleCategory = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           inherit systems;
-          modules = [
-            ({ system, ... }: { packages.foo = "foo-${system}"; })
-          ];
+          perSystem = { system, ... }: { packages.foo = "foo-${system}"; };
         };
       in
       result.packages;
@@ -28,12 +25,9 @@ in
   testMultipleCategories = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           inherit systems;
-          modules = [
-            ({ system, ... }: { packages.foo = "pkg-${system}"; checks.bar = "chk-${system}"; })
-          ];
+          perSystem = { system, ... }: { packages.foo = "pkg-${system}"; checks.bar = "chk-${system}"; };
         };
       in
       {
@@ -56,17 +50,13 @@ in
   testCategorySubset = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           inherit systems;
-          modules = [
-            ({ system, ... }:
-              { packages.foo = "foo-${system}"; }
-              // (if system == "x86_64-linux"
-                  then { checks.linux-only = "linux-check"; }
-                  else {})
-            )
-          ];
+          perSystem = { system, ... }:
+            { packages.foo = "foo-${system}"; }
+            // (if system == "x86_64-linux"
+                then { checks.linux-only = "linux-check"; }
+                else {});
         };
       in
       {

--- a/tests/tree-construction.nix
+++ b/tests/tree-construction.nix
@@ -8,23 +8,22 @@ let
     in !result.success;
 in
 {
-  # perSystem + modules combined
-  testPerSystemAndModules = {
+  # perSystem + imports combined
+  testPerSystemAndImports = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
           perSystem = { pkgs, ... }: { packages.from-perSystem = "ps"; };
-          modules = [
-            ({ pkgs, ... }: { packages.from-modules = "mod"; })
+          imports = [
+            { perSystem = { pkgs, ... }: { packages.from-import = "mod"; }; }
           ];
         };
       in
       result.packages.${sys};
     expected = {
       from-perSystem = "ps";
-      from-modules = "mod";
+      from-import = "mod";
     };
   };
 
@@ -32,10 +31,9 @@ in
   testConfigOptions = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
+          imports = [
             {
               name = "mymod";
               options.greeting = { type = types.string; default = "hello"; };
@@ -53,13 +51,12 @@ in
   testMultipleCategories = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
-          modules = [
-            ({ pkgs, ... }: { packages.pkg1 = "p1"; })
-            ({ pkgs, ... }: { checks.chk1 = "c1"; })
-            ({ pkgs, ... }: { devShells.default = "ds"; })
+          imports = [
+            { perSystem = { pkgs, ... }: { packages.pkg1 = "p1"; }; }
+            { perSystem = { pkgs, ... }: { checks.chk1 = "c1"; }; }
+            { perSystem = { pkgs, ... }: { devShells.default = "ds"; }; }
           ];
         };
       in
@@ -75,8 +72,7 @@ in
   testFlakeAndPerSystem = {
     expr =
       let
-        result = lib.mkFlake {
-          inputs = { nixpkgs = nixpkgs; };
+        result = lib.mkFlake { inputs = { inherit nixpkgs; }; } {
           systems = [ sys ];
           perSystem = { pkgs, ... }: { packages.hello = "hello"; };
           flake = { nixosModules.default = "mod"; };


### PR DESCRIPTION
This makes adios-flake usable as a `follows` target for flake-parts in dependent flakes:

  inputs.someFlake.inputs.flake-parts.follows = "adios-flake";

The previous single-arg form mixed `inputs` (an evaluation context) with `systems`/`perSystem`/`flake` (the module body) in one record, which made adios-flake structurally incompatible with the flake-parts ecosystem despite being semantically equivalent. By adopting the curried form

  mkFlake { inherit inputs; } module

`module` becomes the same recursive { systems, imports, perSystem, flake } shape that flake-parts uses, and `self` is read from `inputs.self` rather than passed separately.

The engine itself shrank in the process. The public `mkFlake` is now a small tree-walker that flattens `imports` and feeds the engine two homogeneous lists: perSystem closures and native adios modules. The engine no longer handles paths, static attrsets, perSystem-as-param, flake-as-function, or `_file` provenance — those concerns moved up into the walker or evaporated. perSystem closures *are* the ergonomic function shape the engine already understands, so they pass through without wrapping.

`withSystem` is fed back into top-level module arguments through the same lazy let-rec fixpoint flake-parts uses; safe to capture in `flake.*` thunks but a genuine cycle if forced while computing `imports` or `systems`.

Memoization is preserved: a `perSystem` that asks for none of pkgs/system/inputs'/self' produces an adios module with no input edge to /nixpkgs, so diff propagation skips it on subsequent systems.

This is signature-level compatibility, not full NixOS module semantics. `imports` are merged structurally — no mkIf, no priorities, no submodule options. Simple flake-parts flakes work; flakes leaning on `flakeModules.partitions` etc. will not.

Native adios modules in `imports` are detected by `impl`, `outputs`, or an explicit `_type = "adiosModule"` marker (only needed for the rare options-only module that has neither) and pass straight through to the engine.

Breaking change. All tests, templates, README, and docs are migrated.

Closes #15.